### PR TITLE
chore: change cloneSubmodule to be true

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "cloneSubmodules": true
 }


### PR DESCRIPTION
[this flag](https://sourcegraph.com/github.com/renovatebot/renovate/-/blob/docs/usage/configuration-options.md#clonesubmodules) is false (default behavior). It may be cause of [`591d260` (#29)](https://github.com/GiganticMinecraft/chunk-search-rs/pull/29/commits/591d2604cce62b6d0d28ce0ae074e4c31f3d22c6#diff-2ea88c7a30351b12a4dcfc06cdce2af6eab18416176466c2500cb6ef74f745bf) .